### PR TITLE
[DICE-43] 팝업 상세 스크린 배경색 일부 변경

### DIFF
--- a/src/screens/popUpDetail/popUpDetail.tsx
+++ b/src/screens/popUpDetail/popUpDetail.tsx
@@ -153,7 +153,7 @@ const PopUpDetailScreen = ({ navigation }: PopUpDetailScreenProps) => {
               </Pressable>
             </View>
 
-            <View className="my-6 h-[1px] bg-[#EEEEEE]" />
+            <View className="my-6 h-[1px] bg-stroke" />
 
             <View className="mb-5 flex flex-row space-x-5">
               <View className="flex flex-col justify-center space-y-2">
@@ -183,7 +183,7 @@ const PopUpDetailScreen = ({ navigation }: PopUpDetailScreenProps) => {
             </View>
           </View>
 
-          <View className="my-6 h-2 bg-light_gray" />
+          <View className="my-6 h-2 bg-back_gray" />
 
           <View className="space-y-4 px-5">
             <Text className="font-SUB2 text-SUB2">팝업공간 소개</Text>
@@ -205,7 +205,7 @@ const PopUpDetailScreen = ({ navigation }: PopUpDetailScreenProps) => {
             </Pressable>
           </View>
 
-          <View className="my-6 h-2 bg-light_gray" />
+          <View className="my-6 h-2 bg-back_gray" />
 
           <View className="space-y-4 px-5">
             <Text className="font-SUB2 text-SUB2">위치 안내</Text>
@@ -258,7 +258,7 @@ const PopUpDetailScreen = ({ navigation }: PopUpDetailScreenProps) => {
             </Pressable>
           </View>
 
-          <View className="my-6 h-2 bg-light_gray" />
+          <View className="my-6 h-2 bg-back_gray" />
 
           <View className="space-y-4 px-5">
             <Text className="font-SUB2 text-SUB2">시설 이용 안내</Text>
@@ -286,11 +286,11 @@ const PopUpDetailScreen = ({ navigation }: PopUpDetailScreenProps) => {
             </Pressable>
           </View>
 
-          <View className="my-6 h-2 bg-light_gray" />
+          <View className="my-6 h-2 bg-back_gray" />
 
           <View className="space-y-4 px-5">
             <Text className="font-SUB2 text-SUB2">공지사항 안내</Text>
-            <View className="flex flex-col space-y-1 rounded-lg bg-light_gray p-4">
+            <View className="flex flex-col space-y-1 rounded-lg bg-back_gray p-4">
               {detailData.noticeInformation.map((item, index) => (
                 <Text key={index} className="font-BODY1 text-BODY1 text-deep_gray">
                   * {item}


### PR DESCRIPTION
## 🚩 관련 이슈
[DESIGN] 팝업 공간 상세 스크린 구분선 색상 변경 #43

## 📌 반영 브랜치
dice-43 -> dev

## 📋 내용
### 💻 팝업 공간 상세 스크린
- [x] 각 내용의 구분선 색상 변경
- [ ] 공지사항 안내의 View의 배경색 변경
<img src="https://github.com/user-attachments/assets/a97577f6-21e0-401b-a8f3-c78a6090daeb" width="250" />
<img src="https://github.com/user-attachments/assets/2161b364-28c7-4c87-a9df-17ebe325d4fc" width="250" />

## 🚨 유의 사항
- [ ]